### PR TITLE
PMK-534-Rawlogs_Remove info cloud storage_EN

### DIFF
--- a/content-delivery/rawlogs/2021-01-14-index.md
+++ b/content-delivery/rawlogs/2021-01-14-index.md
@@ -9,17 +9,6 @@ O log de acesso (access_log) traz informações que lhe permitirão conduzir aud
 > 1. [Como funciona](#como-funciona)
 > 2. [Formato do log](#formato-do-log)
 > 3. [Como configurar](#como-configurar)
-# Rawlogs
-
-[Edit on GitHub <svg width="14" height="14" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#F3652B"><path d="M4.81.71H.672v11.43H12.1V8.001" stroke-width=".8"/><path d="M6.87.786h5.155V5.94M6.31 6.5L12.026.786"/></g></svg>](https://github.com/aziontech/docs_en/edit/master/content-delivery/rawlogs/2021-01-14-index.md)
-
-Você pode ter acesso aos logs de todas as requisições de seus usuários que passaram pela Azion por meio do produto Rawlogs.
-
-O log de acesso (access_log) traz informações que lhe permitirão conduzir auditorias, _troubleshooting_, análise de performance ou _data mining_.
-
-> 1. [Como funciona](#como-funciona)
-> 2. [Formato do log](#formato-do-log)
-> 3. [Como configurar](#como-configurar)
 
 ---
 
@@ -28,8 +17,6 @@ O log de acesso (access_log) traz informações que lhe permitirão conduzir aud
 Ao configurar o Rawlogs, os Edge Servers da Azion passam a coletar logs de acesso de seus usuários, que são consolidados de hora em hora e disponibilizados para download. Você pode transferir os arquivos de log para a sua estação de trabalho usando FTP.
 
 Os arquivos de log são armazenados em formato texto comprimido (gzip), divididos por dia e utilizam o horário UTC (3 horas a frente do horário de Brasília).
-
-Após 45 dias, os logs mais antigos são removidos do Cloud Storage e não poderão ser recuperados. Você deve estabelecer uma rotina de transferência dos arquivos para um local de armazenamento permanente, se desejar manter os arquivos por mais tempo.
 
 ---
 


### PR DESCRIPTION
@Sabrinacmoreira , aqui no content delivery, na parte de Rawlog, eu tirei a info de cloud storage como vc pediu ...
Como essa doc é antiga, devo arrumar os passos? Pois não há mais esse menu content delivery, certo?

Acesse o Real-Time Manager e entre no menu Content Delivery.
Edite a configuração de Content Delivery para a qual deseja habilitar o Rawlogs.
Quem vc sugere de outro reviewer aqui?
Thanks:)