### PR TITLE
fix: Remove WAF from Rules Engine Edge Application API

### DIFF
--- a/api/v3/edge-applications/rules-engine/2021-01-14-index.md
+++ b/api/v3/edge-applications/rules-engine/2021-01-14-index.md
@@ -279,7 +279,6 @@ Check below the list of behaviors that can be applied:
 | Run Function                        | run_function           |
 | Set Cache Policy                    | set_cache_policy       |
 | Set Origin                          | set_origin             |
-| Set WAF Rule Set                    | filter_request_cookie  |
 
 **Request Example**
 


### PR DESCRIPTION
Set WAF behavior was moved to Edge Firewall