### PR TITLE
Update for minor description enhancement

### DIFF
--- a/edge-application/rules-engine/2021-01-14-index.md
+++ b/edge-application/rules-engine/2021-01-14-index.md
@@ -97,14 +97,14 @@ In the Criteria you define the conditions for executing the rule. You can use a 
 | ${upstream_cookie_name} | Value of cookie name sent by the origin using the Set-Cookie header field. If multiple origins are consulted during the processing of the request, only cookies from the last origin are stored. | Response Phase | Application Acceleration |
 | ${upstream_http_name} | Value of the name header field sent by the origin. The name argument must be converted to lowercase and the hyphens must be converted to underscore. If multiple origins are consulted during the processing of the request, only headers from the last origin are stored. For example: ${Upstream_http_server} will assume the value of the Server header field sent by the last queried origin. | Response Phase | Application Acceleration |
 | ${upstream_status} | Status code of the origin response sent to Intelligent Edge. If multiple origins are consulted during the processing of the request, the status codes will be separated by a comma. If an internal redirect from one group of servers to another occurs, initiated by an “X-Accel-Redirect” or an error page, the status codes of the different groups will be separated by “:”. | Response Phase | Application Acceleration |
-| ${uri} | The normalized URI of the request. The value of $ {uri} can change during the processing of a request, for example, when an internal redirect occurs or when index files are used. | Response Phase | - |
+| ${uri} | The normalized (urldecoded) URI of the request. The value of $ {uri} can change during the processing of a request, for example, when an internal redirect occurs or when index files are used. It does NOT carry the Query String parameters as ${request_uri} do. | Response Phase | - |
 
 
 **Comparison Operators**
 
 The condition for the execution of a rule must be the comparison of a variable with an argument. The comparison operators are:
 
-| Operador | Descrição | Argumento |
+| Operator | Description | Argument |
 |----------|-----------|-----------|
 | is equal | The value of the variable is equal to the argument, compared character by character. | string |
 | is not equal | The value of the variable is not exactly the same as the argument. | string |


### PR DESCRIPTION
- Corrected translation on headings of the table in "Comparison Operators";
- Added user-friendly explanation about ${uri} variable and its "sister" ${request_uri}.