### PR TITLE
Update Request URI field for disambiguation

### DIFF
--- a/products/edge-firewall/rules-engine/2021-01-14-index.md
+++ b/products/edge-firewall/rules-engine/2021-01-14-index.md
@@ -61,7 +61,7 @@ It determines the set of conditions that need to be met for the execution of *Be
 | Network                | The IP address of the client making the HTTP request, which can be used for any network comparison (CIDR, ASN or Country). | Network Layer Protection |
 | Request Args           | All arguments sent by the user in the request string (*query string*). | Web Application Firewall |
 | Request Method         | The request's HTTP method. For example: GET, POST, PUT, etc. | -                        |
-| Request URI            | URI of the request.                                          | -                        |
+| Request URI            | This relates to the $ {uri} variable from Rules Engine for Edge Applications. The normalized (urldecoded) URI of the request. The value of $ {uri} can change during the processing of a request, for example, when an internal redirect occurs or when index files are used. It does NOT carry the Query String parameters as ${request_uri} do.| -                        |
 | *Scheme*               | The scheme of the request: http or https.                    | -                        |
 
 


### PR DESCRIPTION
The term "Request URI" may be confusing and mislead the user to understand it as the same ${request_uri} on Edge Applications, wich is not true.
The edit aims to clarify this.